### PR TITLE
fix `quake(Intensity)` guard example in `basics.md`

### DIFF
--- a/basics.md
+++ b/basics.md
@@ -392,7 +392,7 @@ Suppose we have a bunch of constraints like `quake(Intensity)`. Our instrument i
 have many small tremors we can discard. Let's discard all quakes less than 3.0 .
 
 ---------------------------------------------
-guard(Intensity) <=> Intensity < 3.0 | true.
+quake(Intensity) <=> Intensity < 3.0 | true.
 
 ---------------------------------------------
 


### PR DESCRIPTION
In the `quake` example in section about guards, the `quake` constraint was instead named `guard`. 