### PR TITLE
constraint systems page

### DIFF
--- a/constraintsystems.md
+++ b/constraintsystems.md
@@ -67,14 +67,6 @@ If we apply `more_than_4` to X then we _subsume_ `more_than_3`. We can discard t
 more_than_4(X) \ more_than_3(X) <=> true.
 ----
 
-
-Since we can later change the constraint we can develop very efficient constraint checkers.
-If we apply `more_than_4` to X then we _subsume_ `more_than_3`. We can discard the weaker constraint.
-
-----
-more_than_4(X) \ more_than_3(X) <=> true.
-----
-
 A simple constraint system
 --------------------------
 

--- a/constraintsystems.md
+++ b/constraintsystems.md
@@ -96,7 +96,7 @@ gofail :- cl_list(X),                              <3>
 Now let's add a minimum length constraint.
 
 ----
-:- chr_constraint cl_min_len/1.
+:- chr_constraint cl_min_len/2.
 
 cl_min_len(X, MinLen) <=>           <1>
          nonvar(X),

--- a/constraintsystems.md
+++ b/constraintsystems.md
@@ -19,7 +19,7 @@ link:final.html[Final]
 
 The material in this chapter depends on understanding constraint systems.
 
-If you want to understand making constraint systems, at least read the intro chapter of my [clp(fd) tutorial](/swipltuts/clpfd/clpfd.html), the Prolog clpfd library notes,
+If you want to understand making constraint systems, at least read the intro chapter of my link:/swipltuts/clpfd/clpfd.html[clp(fd) tutorial], the Prolog clpfd library notes,
 and the entries for attributed variables in the SWI-Prolog manual.
 
 .Review

--- a/constraintsystems.md
+++ b/constraintsystems.md
@@ -39,11 +39,13 @@ There is an important exception to this rule. If the **guard** encounters `groun
 (not the constraints) will **reactivate** when the argument of `ground/1` is **grounded**.
 
 ----
-more_than_3(N) <=>  ground(N), N > 3 | writeln('fired').
+more_than_3(N) <=> ground(N), N > 3 | writeln('more').
+more_than_3(N) <=> ground(N) | writeln('not more'), fail.
 
-?-more_than_3(X),writeln('middle'),X = 2.
+?- more_than_3(X), writeln('middle'), X = 2.
 middle
-fired.
+not more
+false.
 ----
 
 `nonvar/1` works the same way.

--- a/constraintsystems.md
+++ b/constraintsystems.md
@@ -39,11 +39,11 @@ There is an important exception to this rule. If the **guard** encounters `groun
 (not the constraints) will **reactivate** when the argument of `ground/1` is **grounded**.
 
 ----
-more_than_3(N) <=>  ground(N), N > 3 | true.
+more_than_3(N) <=>  ground(N), N > 3 | writeln('fired').
 
 ?-more_than_3(X),writeln('middle'),X = 2.
 middle
-false.
+fired.
 ----
 
 `nonvar/1` works the same way.


### PR DESCRIPTION
I had some trouble reproducing the exact output you showed in the example of a `ground/1` in the guard delaying activation of a rule (I tried v7.7.15 and v8.1.17). That got me to thinking that I wasn't sure the existing example really proved to me what was happening. I played with it some until I came up with the modified example in this pull request. What do you think?